### PR TITLE
Included kaiheilos/Utilities project clone directory into .gitignore for simplification in project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# kaiheilos/Utilities project clone at RemnantETS/AuriHellMod project root
+# https://github.com/kaiheilos/Utilities
+/Utilities
+
 500-ModName_P.pak
 666-ModName_P.pak
 *.txt

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# AuriHellMod
+
+## Basic Modding Instructions
+Please visit [Basic Modding](https://github.com/RemnantETS/AuriHellMod/wiki/Basic-Modding) for instructions on how to prepare your development environment.


### PR DESCRIPTION
To allow localization of project tooling, I have included the kaiheilos/Utilities project clone directory in the .gitignore file.  This will allow ease in project setup documentation and avoid questions regarding where the dependency should reside from developers.